### PR TITLE
feat: Added MySQL dialect and completion keymap

### DIFF
--- a/src/renderer/components/CodeEditor/SqlCodeEditor.tsx
+++ b/src/renderer/components/CodeEditor/SqlCodeEditor.tsx
@@ -5,7 +5,7 @@ import CodeMirror, {
 import { acceptCompletion, completionStatus } from '@codemirror/autocomplete';
 import { defaultKeymap, insertTab } from '@codemirror/commands';
 import { keymap } from '@codemirror/view';
-import { SQLConfig, sql } from '@codemirror/lang-sql';
+import { SQLConfig, sql, MySQL } from '@codemirror/lang-sql';
 import { Ref, forwardRef } from 'react';
 import useCodeEditorTheme from './useCodeEditorTheme';
 
@@ -39,6 +39,7 @@ const SqlCodeEditor = forwardRef(function SqlCodeEditor(
           ...defaultKeymap,
         ]),
         sql({
+          dialect: MySQL,
           schema,
         }),
       ]}

--- a/src/renderer/components/CodeEditor/SqlCodeEditor.tsx
+++ b/src/renderer/components/CodeEditor/SqlCodeEditor.tsx
@@ -2,7 +2,11 @@ import CodeMirror, {
   ReactCodeMirrorProps,
   ReactCodeMirrorRef,
 } from '@uiw/react-codemirror';
-import { acceptCompletion, completionStatus } from '@codemirror/autocomplete';
+import {
+  acceptCompletion,
+  completionStatus,
+  startCompletion,
+} from '@codemirror/autocomplete';
 import { defaultKeymap, insertTab } from '@codemirror/commands';
 import { keymap } from '@codemirror/view';
 import { SQLConfig, sql, MySQL } from '@codemirror/lang-sql';
@@ -35,6 +39,12 @@ const SqlCodeEditor = forwardRef(function SqlCodeEditor(
               }
               return true;
             },
+          },
+          {
+            key: 'Ctrl-Space',
+            mac: 'Cmd-i',
+            preventDefault: true,
+            run: startCompletion,
           },
           ...defaultKeymap,
         ]),


### PR DESCRIPTION
Temporary use MySQL dialect, added keymap for calling the autocompletion, window will use `ctrl + space` , while mac will use `command + i`, this follow the default key-binding from vscode.