### PR TITLE
feat: add onCopyAsMarkdown in the useDataTableContextMenu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "querymaster",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "querymaster",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-master",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-master",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "hasInstallScript": true,
       "license": "MIT"
     }

--- a/src/renderer/screens/DatabaseScreen/QueryResultViewer/useDataTableContextMenu.tsx
+++ b/src/renderer/screens/DatabaseScreen/QueryResultViewer/useDataTableContextMenu.tsx
@@ -71,6 +71,19 @@ export default function useDataTableContextMenu({
       );
     }
 
+    function onCopyAsMarkdown() {
+      const selectedRows = selectedRowsIndex.map((rowIndex) => data[rowIndex].data);
+      const displayableRows = getDisplayableFromDatabaseRows(selectedRows, headers);
+      const headerNames = headers.map((header) => header.name);
+      const markdownString = [headerNames.join(' | ')];
+      markdownString.push(new Array(headerNames.length).fill('---').join(' | '));
+      markdownString.push(
+        ...displayableRows.map((row) => headerNames.map((header) => row[header]).join(' | '))
+      );
+
+      window.navigator.clipboard.writeText(markdownString.join('\n'));
+    }
+
     const lastSelectedRow =
       selectedRowsIndex.length > 0
         ? data[selectedRowsIndex[selectedRowsIndex.length - 1]]
@@ -90,6 +103,7 @@ export default function useDataTableContextMenu({
           { text: 'As Excel', onClick: onCopyAsExcel },
           { text: 'As CSV', disabled: true },
           { text: 'As JSON', onClick: onCopyAsJson },
+          { text: 'As Markdown', onClick: onCopyAsMarkdown },
           { text: 'As SQL', disabled: true },
         ],
       },


### PR DESCRIPTION
resolves #126
Formats the highlighted entrys so they are properly presented in markdown files (as seen in the screenshots)

![image](https://github.com/invisal/query-master/assets/44345551/26f5e357-1790-46fc-8894-a94f2daceeff)

![image](https://github.com/invisal/query-master/assets/44345551/538af618-371b-496b-a433-9c624c432ce7)

![image](https://github.com/invisal/query-master/assets/44345551/1168f8a0-49eb-41f9-9e74-3a85e5909e97)

